### PR TITLE
feat: control flags to robot

### DIFF
--- a/commConfig.h
+++ b/commConfig.h
@@ -149,7 +149,9 @@ typedef struct {
   uint8_t dribbler : 1;
   int16_t dribblerSpeed : 11;
   uint8_t command : 8;
-  uint64_t free_1 : 61;
+  uint8_t robotLockedToMove : 1;
+  uint8_t criticalMoveTurbo : 1;
+  uint64_t free_1 : 59;
 
 } packetTypeSpeedSSL;
 
@@ -174,9 +176,9 @@ typedef struct {
   int16_t y : 16; // -32.767 - 32.767 m
   int16_t w : 16; // 0 - 6.5535 rad
   // motion parameters
-  uint16_t maxSpeed : 12; // 0 - 4.095 m/s
-  uint16_t minSpeed : 12; // 0 - 4.095 m/s
-  uint16_t rotateKp : 10; // 0 - 10.23
+  uint16_t maxSpeed : 12;               // 0 - 4.095 m/s
+  uint16_t minSpeed : 12;               // 0 - 4.095 m/s
+  uint16_t rotateKp : 10;               // 0 - 10.23
   uint8_t usingPropSpeed : 1;
   uint16_t minDistanceToPropSpeed : 12; // 0 - 4.095 m
   uint8_t clockwise : 1;                // In goToPoint it is High Acceleration flag
@@ -207,11 +209,11 @@ typedef struct {
   int16_t dribbler : 15; // -1638.3 - 1638.3 rad/s
   uint8_t kickLoad : 8;  // 0 - 2.55
   bool ball : 1;
-  uint8_t battery : 8; // 0 - 25.5 V
-  int16_t m1 : 16;     // -327.67 - 327.67 m/s
-  int16_t m2 : 16;     // -327.67 - 327.67 m/s
-  int16_t m3 : 16;     // -327.67 - 327.67 m/s
-  int16_t m4 : 16;     // -327.67 - 327.67 m/s
+  uint8_t battery : 8;   // 0 - 25.5 V
+  int16_t m1 : 16;       // -327.67 - 327.67 m/s
+  int16_t m2 : 16;       // -327.67 - 327.67 m/s
+  int16_t m3 : 16;       // -327.67 - 327.67 m/s
+  int16_t m4 : 16;       // -327.67 - 327.67 m/s
   uint8_t pcktCount : 8;
 
 } packetTypeTelemetry;
@@ -264,11 +266,11 @@ typedef struct {
   int16_t dribbler : 15; // -1638.3 - 1638.3 rad/s
   uint8_t kickLoad : 8;  // 0 - 2.55
   bool ball : 1;
-  uint8_t battery : 8; // 0 - 25.5 V
-  int16_t m1 : 16;     // -327.67 - 327.67 m/s
-  int16_t m2 : 16;     // -327.67 - 327.67 m/s
-  int16_t m3 : 16;     // -327.67 - 327.67 m/s
-  int16_t m4 : 16;     // -327.67 - 327.67 m/s
+  uint8_t battery : 8;   // 0 - 25.5 V
+  int16_t m1 : 16;       // -327.67 - 327.67 m/s
+  int16_t m2 : 16;       // -327.67 - 327.67 m/s
+  int16_t m3 : 16;       // -327.67 - 327.67 m/s
+  int16_t m4 : 16;       // -327.67 - 327.67 m/s
   uint8_t pcktCount : 8;
 
 } packetTypeOdometry;

--- a/nRF24Communication.cpp
+++ b/nRF24Communication.cpp
@@ -179,6 +179,8 @@ bool nRF24Communication::updatePacket() {
           this->_kick.dribbler = static_cast<bool>(this->_mSSL.decoded.dribbler);
           this->_kick.dribblerSpeed =
               static_cast<float>((this->_mSSL.decoded.dribblerSpeed) / 10.0);
+          this->_moveIsLocked = static_cast<bool>(this->_mSSL.decoded.robotLockedToMove);
+          this->_criticalMoveTurbo = static_cast<bool>(this->_mSSL.decoded.criticalMoveTurbo);
         } else if (this->_lastPacketType == msgType::POSITION) {
           this->clearSSLDataPosition();
           this->clearSSLDataKick();
@@ -302,6 +304,8 @@ void nRF24Communication::clearSSLDataSpeed() {
   this->_v.x = 0;
   this->_v.y = 0;
   this->_v.w = 0;
+  this->_moveIsLocked = false;
+  this->_criticalMoveTurbo = false;
 }
 
 void nRF24Communication::clearSSLDataPosition() {
@@ -374,4 +378,12 @@ float nRF24Communication::getKD() {
 }
 float nRF24Communication::getAlpha() {
   return _alpha;
+}
+
+bool nRF24Communication::robotMoveIsLocked() {
+  return _moveIsLocked;
+}
+
+bool nRF24Communication::robotMoveCriticalTurbo() {
+  return _criticalMoveTurbo;
 }

--- a/nRF24Communication.h
+++ b/nRF24Communication.h
@@ -53,6 +53,8 @@ class nRF24Communication {
   void getPosition(RobotPosition& pos);
   refereeCommand getGameState();
   RobotPosition getLastPosition();
+  bool robotMoveIsLocked();
+  bool robotMoveCriticalTurbo();
 
   // Aux Info
   float getKP();
@@ -89,6 +91,8 @@ class nRF24Communication {
   Motors _motorSpeed;
   bool _isPWM;
   Vector _v;
+  bool _moveIsLocked;
+  bool _criticalMoveTurbo;
   KickFlags _kick;
   RobotPosition _pos;
   float _kp, _kd, _ki, _alpha;


### PR DESCRIPTION
Adds control flags to SSL Robot speed packet:
- bool _moveIsLocked: robot movement is locked by obstacle
- bool _criticalMoveTurbo: robot is not locked and needs to accelerate fast

The flags are sent from the high-level software and the approach was validated during the RoboCup tests and competition.

The robot's behavior will not be affected if no flags are received.