### PR TITLE
feat: return connection to radio status after setup

### DIFF
--- a/nRF24Communication.cpp
+++ b/nRF24Communication.cpp
@@ -25,7 +25,14 @@ int nRF24Communication::setup(int robotSwitches) {
   this->enable();
   this->_configure();
   this->disable();
-  return 0;
+  bool connected = this->_radio.getPALevel() == RF24_PA_MAX;
+  bool channel = false;
+  if(this->_config.function == RadioFunction::receiver){
+    channel = this->compareChannel(this->_config.receiveChannel);
+  } else {
+    channel = this->compareChannel(this->_config.sendChannel);
+  }
+  return connected && channel;
 }
 
 bool nRF24Communication::resetRadio() {


### PR DESCRIPTION
This pull request implements the functionality to return the radio connection status after the initial setup. The modification was made in the nRF24Communication.cpp file, where the following changes were introduced:

1. Connection Check Addition: After the execution of the enable(), configure(), and disable() methods, a check was introduced to determine if the radio is connected with maximum power level (RF24_PA_MAX).
2. Channel Determination: Depending on the configuration function (_config.function), a channel comparison is made to check if the radio is in receiving or sending mode.
3. Status Return: The method now returns a boolean value indicating if the radio is connected and on a valid channel.

**Important Changes to be checked**
* A significant change in this pull request is the modification of the return type of the setup() function. Previously, the function always returned 0,. With this update, setup() now returns a value 0 or 1 indicating the actual status of the radio connection and channel validation. Specifically, it returns 1 if the radio is connected and on a valid channel, and 0 otherwise.