### PR TITLE
fix: change velocity type

### DIFF
--- a/nRF24Communication.cpp
+++ b/nRF24Communication.cpp
@@ -279,9 +279,9 @@ bool nRF24Communication::sendOdometryPacket(RobotInfo odometry) {
   return answer;
 }
 
-void nRF24Communication::getDifferentialSpeed(Motors& mSpeed) {
-  mSpeed.m1 = this->_motorSpeed.m1;
-  mSpeed.m2 = this->_motorSpeed.m2;
+void nRF24Communication::getDifferentialSpeed(Vector& velocity) {
+  velocity.x = this->_motorSpeed.m1;
+  velocity.w = this->_motorSpeed.m2;
 }
 
 void nRF24Communication::clearVSSData() {

--- a/nRF24Communication.h
+++ b/nRF24Communication.h
@@ -38,7 +38,7 @@ class nRF24Communication {
   void disable();
 
   // VSS Info
-  void getDifferentialSpeed(Motors& mSpeed);
+  void getDifferentialSpeed(Vector& velocity);
   void clearVSSData();
 
   // SSL Info


### PR DESCRIPTION
Este PR ajusta a assinatura da função `getDifferentialSpeed` para refletir corretamente o novo tipo de dado utilizado na representação de velocidade diferencial.

### 🛠️ Alterações:

* Modificada a função `getDifferentialSpeed` para aceitar um parâmetro do tipo `Vector` em vez de `Motors`.
* Atualizados os nomes dos componentes retornados:

  * `m1` → `x`
  * `m2` → `w`

### 📌 Motivo:

A mudança padroniza o uso do tipo `Vector` para representar velocidades diferenciais no sistema, garantindo maior consistência na interface de comunicação.

### 📂 Arquivos modificados:

* `nRF24Communication.cpp`
* `nRF24Communication.h`